### PR TITLE
Update app.yaml

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,5 +1,4 @@
 application: helloworld
-version: 1
 runtime: php55
 api_version: 1
 


### PR DESCRIPTION
Updated app.yaml file per

ERROR: The [version] field is specified in file [/Users/alwong/sandbox/jQuery-autoComplete/app.yaml]. This field is not used by gcloud and must be removed. Versions are generated automatically by default but can also be manually specified by setting the `--version` flag on individual command executions.